### PR TITLE
Add latent heat flux from ice shelves into the ocean

### DIFF
--- a/src/ice_shelf/MOM_ice_shelf.F90
+++ b/src/ice_shelf/MOM_ice_shelf.F90
@@ -1454,10 +1454,12 @@ subroutine add_shelf_flux(G, US, CS, sfc_state, fluxes, time_step)
     endif
 
     if (associated(fluxes%sens)) &
-      fluxes%sens(i,j) = frac_shelf*ISS%tflux_ocn(i,j)*CS%flux_factor + frac_open * fluxes%sens(i,j)
+      fluxes%sens(i,j) = frac_shelf*ISS%tflux_ocn(i,j) + frac_open * fluxes%sens(i,j)
     ! The salt flux should be mostly from sea ice, so perhaps none should be intercepted and this should be changed.
     if (associated(fluxes%salt_flux)) &
       fluxes%salt_flux(i,j) = frac_shelf * ISS%salt_flux(i,j)*CS%flux_factor + frac_open * fluxes%salt_flux(i,j)
+    if (associated(fluxes%latent)) &
+      fluxes%latent(i,j) = fluxes%latent(i,j) - frac_shelf * ISS%water_flux(i,j) * CS%Lat_Fusion
   endif ; enddo ; enddo
 
   if (CS%debug) then


### PR DESCRIPTION
Calculate latent heat flux (W m-2) into the ocean from ice-shelf melt/refreezing and add it to the fluxes structure, so that it is  present in the "latent" ocean diagnostic. Negative means ocean heat loss.

Also removed an extra `flux_factor` that is multiplied with `tflux_ocn` when calculating ice-shelf sensible heat flux. This flux factor was already applied earlier in the code.